### PR TITLE
[Feature/RP-97 Connect RoutineResult - View

### DIFF
--- a/Routine/Routine/Models/RoutineData/RoutineData.swift
+++ b/Routine/Routine/Models/RoutineData/RoutineData.swift
@@ -16,6 +16,8 @@ struct RoutineData: JSONCodable, CustomStringConvertible {
                                   startDate: MockData.date,
                                   repeatation: .default)
     
+    private static let routineResultManager = RoutineResultManager.shared
+    
     //식별자 - RoutineID(타입별칭)
     let id: RoutineID
     
@@ -75,6 +77,13 @@ struct RoutineData: JSONCodable, CustomStringConvertible {
         self.alarm = alarm
     }
     
+    func result(at date: Date) -> RoutineResult {
+        guard let result = Self.routineResultManager.read(date, id) else {
+            return RoutineResult(dateID: date, routineID: id)
+        }
+        
+        return result
+    }
 }
 
 

--- a/Routine/Routine/Models/RoutineData/RoutineData.swift
+++ b/Routine/Routine/Models/RoutineData/RoutineData.swift
@@ -117,7 +117,7 @@ extension RoutineData: Equatable {
 
 }
 
-private extension Date {
+extension Date {
     
     func yyyyMMdd() -> String {
         let year = Calendar.current.component(.year, from: self)

--- a/Routine/Routine/Models/RoutineResult/RoutineResult.swift
+++ b/Routine/Routine/Models/RoutineResult/RoutineResult.swift
@@ -9,14 +9,6 @@ import Foundation
 
 // 루틴 결과
 struct RoutineResult: CustomStringConvertible {
-    var description: String {
-        """
-        [RoutineResult]
-        dateID: \(dateID)
-        routineID: \(routineID)
-        isCompleted: \(isCompleted)
-        """
-    }
     
     // 날짜ID 식별자
     let dateID: Date
@@ -25,6 +17,15 @@ struct RoutineResult: CustomStringConvertible {
 
     // 완료 여부
     private(set) var isCompleted: Bool
+    
+    var description: String {
+        """
+        [RoutineResult]
+        dateID: \(dateID)
+        routineID: \(routineID)
+        isCompleted: \(isCompleted)
+        """
+    }
     
     /// 미완료/완료 토글
     mutating func toggle() -> Bool {

--- a/Routine/Routine/Models/RoutineResult/RoutineResult.swift
+++ b/Routine/Routine/Models/RoutineResult/RoutineResult.swift
@@ -28,9 +28,8 @@ struct RoutineResult: CustomStringConvertible {
     }
     
     /// 미완료/완료 토글
-    mutating func toggle() -> Bool {
+    mutating func toggle() {
         self.isCompleted.toggle()
-        return isCompleted
     }
         
     init(dateID: Date,
@@ -50,14 +49,14 @@ extension RoutineResult: Equatable {
     /// 동일한 ID 인지 검증
     static func == (_ lhs: RoutineResult, _ rhs: RoutineResult) -> Bool {
         guard lhs.routineID == rhs.routineID,
-              lhs.dateID == rhs.dateID else { return false }
+              lhs.dateID.yyyyMMdd() == rhs.dateID.yyyyMMdd() else { return false }
         
         return true
     }
     
     // 날짜를 통한 검증
     func isCorrect(_ dateID: Date) -> Bool {
-        self.dateID == dateID
+        self.dateID.yyyyMMdd() == dateID.yyyyMMdd()
     }
     
 }

--- a/Routine/Routine/Models/RoutineResult/RoutineResultManager.swift
+++ b/Routine/Routine/Models/RoutineResult/RoutineResultManager.swift
@@ -82,11 +82,15 @@ extension RoutineResultManager {
         do {
             let routineResultCoreDatas = try fetchRoutineResultCoreData()
             
-            routineResultCoreDatas.forEach { routineResultCoreData in
+            for routineResultCoreData in routineResultCoreDatas {
                 if routineResultCoreData.isSame(routineResult) {
                     routineResultCoreData.set(routineResult)
+                    return
                 }
             }
+            
+            create(routineResult)
+            
             try container.viewContext.save()
         } catch let error {
             print("update: \(error)")
@@ -121,6 +125,15 @@ extension RoutineResultManager {
         }
     }
     
+    func readAll() {
+        do {
+            let routineResultCoreDatas = try fetchRoutineResultCoreData()
+            let string = routineResultCoreDatas.compactMap { $0.convertTo() }.map { String(describing: $0) }.joined(separator: "\n")
+            print(string)
+        } catch {
+            print("readAll fail")
+        }
+    }
 }
 
 // MARK: - 내부 사용 메서드

--- a/Routine/Routine/Models/RoutineResult/RoutineResultManager.swift
+++ b/Routine/Routine/Models/RoutineResult/RoutineResultManager.swift
@@ -57,23 +57,24 @@ extension RoutineResultManager {
         }
     }
     
-    // 날짜에 해당하는 RoutineResult 배열을 반환
-    func read(_ date: Date) -> [RoutineResult] {
-        var routineResults: [RoutineResult] = []
-        
+    /// dateID / routineID 를 통해 RoutineResult? 반환
+    func read(_ dateID: Date, _ routineID: UUID) -> RoutineResult? {
         do {
             let routineResultCoreDatas = try fetchRoutineResultCoreData()
+            let testRoutineResult = RoutineResult(dateID: dateID, routineID: routineID)
             
-            routineResultCoreDatas.forEach { routineResultCoreData in
-                if let routineResult = routineResultCoreData.convertTo(),
-                   routineResult.isCorrect(date) {
-                    routineResults.append(routineResult)
+            for routineResultCoreData in routineResultCoreDatas {
+                if routineResultCoreData.isSame(testRoutineResult),
+                   let routineResult = routineResultCoreData.convertTo() {
+                    return routineResult
                 }
             }
+            
         } catch let error {
             print("read: \(error)")
         }
-        return routineResults
+        
+        return nil
     }
     
     /// routineResults 를 통해 업데이트

--- a/Routine/Routine/Models/RoutineResult/RoutineResultManagerTester.swift
+++ b/Routine/Routine/Models/RoutineResult/RoutineResultManagerTester.swift
@@ -19,10 +19,11 @@ struct RoutineResultManagerTester {
     private let falseResult = MockData.falseRoutineResult
     private let trueResult = MockData.trueRoutineResult
     private let date = MockData.date
+    private let id = MockData.uuid
     
     // 현재 테스트 데이터
-    private var currentResult: [RoutineResult] {
-        manager.read(date)
+    private var currentResult: RoutineResult? {
+        manager.read(date, id)
     }
     
     // 전체 데이터 테스트
@@ -38,21 +39,21 @@ struct RoutineResultManagerTester {
         manager.create(trueResult)
 
         currentResultPrint()
-        let createResult = currentResult.count == 1 && currentResult[0] == falseResult
+        let createResult = currentResult == falseResult
         testResultPrint("create", result: createResult)
         
         // update 테스트
         testStartPrint("update")
         manager.update(trueResult)
         currentResultPrint()
-        let updateResult = currentResult.count == 1 && currentResult[0] == trueResult
+        let updateResult = currentResult == trueResult
         testResultPrint("update", result: updateResult)
         
         // delete 테스트
         testStartPrint("delete")
         manager.delete(falseResult)
         currentResultPrint()
-        let deleteResult = currentResult.isEmpty
+        let deleteResult = currentResult == nil
         testResultPrint("delete", result: deleteResult)
         
         // 테스트 완료 후 데이터 초기화
@@ -61,12 +62,12 @@ struct RoutineResultManagerTester {
     
     // 현재의 테스트 데이터 출력
     private func currentResultPrint() {
-        guard !currentResult.isEmpty else {
+        guard currentResult == nil else {
             print("\n currentResult is empty \n")
             return
         }
         
-        let currentResultString = currentResult.map { String(describing: $0) }.joined(separator: "\n")
+        let currentResultString = String(describing: currentResult)
         print("\n\(currentResultString)\n")
     }
     

--- a/Routine/Routine/Models/WholeDataManager.swift
+++ b/Routine/Routine/Models/WholeDataManager.swift
@@ -1,0 +1,55 @@
+//
+//  DataManager.swift
+//  Routine
+//
+//  Created by t2023-m0072 on 12/22/24.
+//
+
+import Foundation
+
+/*
+(Date) -> 루틴 리스트 -> 결과 리스트
+
+ 
+ */
+
+class WholeDataManager {
+    
+    static let shared = WholeDataManager()
+    
+    private init() {}
+    
+    private let routineManager = RoutineManager.shared
+    private let routineResultManager = RoutineResultManager.shared
+    
+    func creat(_ wholeData: WholeData) {
+        routineManager.create(wholeData.routine)
+        routineResultManager.create(wholeData.result)
+    }
+    
+    func read(at date: Date) -> [WholeData] {
+        let routines = routineManager.read(date)
+        let wholeDatas = routines.map { wholeData($0, date) }
+        
+        return wholeDatas
+    }
+    
+    func update(_ wholeData: WholeData) {
+        routineManager.update(wholeData.routine)
+        routineResultManager.update(wholeData.result)
+    }
+    
+    func delete(_ wholeData: WholeData) {
+        routineManager.delete(wholeData.routine)
+        routineResultManager.delete(wholeData.result)
+    }
+    
+    private func wholeData(_ routine: RoutineData, _ date: Date) -> WholeData {
+        let routine = routine
+        let result = routine.result(at: date)
+        
+        return (routine: routine, result: result)
+    }
+}
+
+typealias WholeData = (routine: RoutineData, result: RoutineResult)

--- a/Routine/Routine/Models/WholeDataManager.swift
+++ b/Routine/Routine/Models/WholeDataManager.swift
@@ -44,6 +44,11 @@ class WholeDataManager {
         routineResultManager.delete(wholeData.result)
     }
     
+    func reset() {
+        routineManager.reset()
+        routineResultManager.reset()
+    }
+    
     private func wholeData(_ routine: RoutineData, _ date: Date) -> WholeData {
         let routine = routine
         let result = routine.result(at: date)

--- a/Routine/Routine/Models/WholeDataManager.swift
+++ b/Routine/Routine/Models/WholeDataManager.swift
@@ -7,12 +7,8 @@
 
 import Foundation
 
-/*
-(Date) -> 루틴 리스트 -> 결과 리스트
 
- 
- */
-
+// 전체 루틴 데이터 매니저 (루틴 데이터 / 루틴 결과)
 class WholeDataManager {
     
     static let shared = WholeDataManager()

--- a/Routine/Routine/ViewControllers/MainRoutineViewController.swift
+++ b/Routine/Routine/ViewControllers/MainRoutineViewController.swift
@@ -9,11 +9,6 @@ import UIKit
 
 import SnapKit
 
-//#Preview {
-//    MainRoutineViewController()
-//    
-//}
-
 // MARK: - MainRoutineViewController
 
 // 루틴 메인 화면 ViewController
@@ -21,6 +16,9 @@ class MainRoutineViewController: UIViewController {
     
     private let wholeDataManager = WholeDataManager.shared
 
+    // 프로퍼티 옵저버를 통해 데이터가 변하기 전 자동으로 코어데이터에 값을 저장시킨다.
+    // TODO: 마지막으로 누른 셀의 경우 데이터가 제대로 저장되지 않는 오류 발생
+    // willSet / didSet 모두 적용시키면 정상 작동하지만 원인을 파악하지 못함
     private var wholeDatas: [WholeData] = [] {
         willSet {
             saveWholeDatas()
@@ -78,14 +76,11 @@ class MainRoutineViewController: UIViewController {
         
         self.view.backgroundColor = .white
 
-        wholeDataManager.reset()
         configureUI()
         setUpRoutineCollectionView()
                 
         updateRoutineDatas()
     }
-
-//    view
     
 }
 
@@ -96,7 +91,6 @@ extension MainRoutineViewController {
     // 전체 레이아웃 설정
     private func configureUI() {
         
-        //addSubView
         [
             calendarModalButton,
             routineCollectionView,
@@ -212,6 +206,7 @@ extension MainRoutineViewController {
         }
         
         let wholeData = wholeDatas[index]
+        routineCollectionViewCell.configurePosition(index: indexPath.item, countOfData: wholeDatas.count)
         routineCollectionViewCell.configureData(wholeData)
         
         return routineCollectionViewCell
@@ -268,6 +263,8 @@ extension MainRoutineViewController: UICollectionViewDataSource {
 
 extension MainRoutineViewController: UICollectionViewDelegate {
     
+    // 셀이 선택되기 전 호출 메서드
+    // 해당 셀의 결과값을 전환시킨다
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         guard let cell = collectionView.cellForItem(at: indexPath) as? RoutineCollectionViewCell else { return false }
         let index = indexPath.item

--- a/Routine/Routine/ViewControllers/MainRoutineViewController.swift
+++ b/Routine/Routine/ViewControllers/MainRoutineViewController.swift
@@ -9,21 +9,19 @@ import UIKit
 
 import SnapKit
 
-#Preview {
-    MainRoutineViewController()
-    
-}
+//#Preview {
+//    MainRoutineViewController()
+//    
+//}
 
 // MARK: - MainRoutineViewController
 
 // 루틴 메인 화면 ViewController
 class MainRoutineViewController: UIViewController {
         
-    // 루틴 데이터 매니저 객체
-    private let routineManager = RoutineManager.shared
     
-    // 루틴 데이터
-    private var routineDatas: [RoutineData] = []
+    private var wholeDatas: [WholeData] = []
+    private let wholeDataManager = WholeDataManager.shared
     
     // 뷰에 로드되는 루틴 날짜
     private var date: Date = Date.now
@@ -78,6 +76,7 @@ class MainRoutineViewController: UIViewController {
         setUpRoutineCollectionView()
                 
         updateRoutineDatas()
+        RoutineResultManagerTester().wholeTest()
     }
     
 }
@@ -120,9 +119,8 @@ extension MainRoutineViewController {
     
     // 루틴 데이터 업데이트 및 컬렉션 뷰 새로고침
     private func updateRoutineDatas() {
-        let datas = routineManager.read(date)
-        
-        self.routineDatas = datas
+        let datas = wholeDataManager.read(at: date)
+        self.wholeDatas = datas
         self.routineCollectionView.reloadData()
     }
     
@@ -191,14 +189,12 @@ extension MainRoutineViewController {
         }
         
         let index = indexPath.item
-        guard routineDatas.count-1 >= index else {
+        guard wholeDatas.count-1 >= index else {
             return RoutineCollectionViewCell()
         }
         
-        let routine = routineDatas[index]
-        routineCollectionViewCell.configureData(routine)
-        routineCollectionViewCell.configurePosition(index: index,
-                                                    countOfData: routineDatas.count)
+        let wholeData = wholeDatas[index]
+        routineCollectionViewCell.configureData(wholeData)
         
         return routineCollectionViewCell
     }
@@ -228,7 +224,7 @@ extension MainRoutineViewController: UICollectionViewDataSource {
         
         switch collectionView {
         case self.routineCollectionView:
-            return routineDatas.count
+            return wholeDatas.count
             
         default:
             return 0

--- a/Routine/Routine/ViewControllers/MainRoutineViewController.swift
+++ b/Routine/Routine/ViewControllers/MainRoutineViewController.swift
@@ -201,7 +201,7 @@ extension MainRoutineViewController {
         }
         
         let index = indexPath.item
-        guard wholeDatas.count-1 >= index else {
+        guard wholeDatas.count - 1 >= index else {
             return RoutineCollectionViewCell()
         }
         

--- a/Routine/Routine/Views/Cells/RoutineBoardCellPosition.swift
+++ b/Routine/Routine/Views/Cells/RoutineBoardCellPosition.swift
@@ -70,7 +70,7 @@ extension RoutineCollectionViewCell {
             init(index: Int, countOfData: Int) {
                 if index == 0 && countOfData > 1 {
                     self = .first
-                } else if index == countOfData-1 {
+                } else if index == countOfData - 1 {
                     self = .last
                 } else {
                     self = .normal

--- a/Routine/Routine/Views/Cells/RoutineCollectionViewCell.swift
+++ b/Routine/Routine/Views/Cells/RoutineCollectionViewCell.swift
@@ -18,6 +18,7 @@ class RoutineCollectionViewCell: UICollectionViewCell {
     static let cornerRadius: CGFloat = 10
     
     // 루틴 데이터
+    // 데이터가 변할 경우 프로퍼티 옵저버를 통해 뷰를 업데이트한다.
     private var wholeData: WholeData? {
         didSet {
             updateData()

--- a/Routine/Routine/Views/Cells/RoutineCollectionViewCell.swift
+++ b/Routine/Routine/Views/Cells/RoutineCollectionViewCell.swift
@@ -18,7 +18,12 @@ class RoutineCollectionViewCell: UICollectionViewCell {
     static let cornerRadius: CGFloat = 10
     
     // 루틴 데이터
-    private var routine: RoutineData?
+    private var wholeData: WholeData? {
+        didSet {
+            updateData()
+        }
+    }
+    
     
     // 전체 스택 뷰
     private var stackView: UIStackView = {
@@ -62,6 +67,18 @@ class RoutineCollectionViewCell: UICollectionViewCell {
         
         return imageView
     }()
+    
+    //
+    private let checkImageView: UIImageView = {
+        let imageView = UIImageView()
+        
+        imageView.backgroundColor = .clear
+        imageView.image = UIImage(systemName: "checkmark.square")
+        imageView.tintColor = .red
+        imageView.isHidden = true
+       
+        return imageView
+    }()
 
     
     override func prepareForReuse() {
@@ -84,10 +101,8 @@ class RoutineCollectionViewCell: UICollectionViewCell {
 
 extension RoutineCollectionViewCell {
     
-    /// 셀 데이터 적용
-    func configureData(_ routine: RoutineData) {
-        self.routine = routine
-        updateData()
+    func configureData(_ wholeData: WholeData) {
+        self.wholeData = wholeData
     }
     
     /// 셀 포지션 적용
@@ -107,7 +122,8 @@ extension RoutineCollectionViewCell {
 
         [
             stackView,
-            stopMarkImageView
+            stopMarkImageView,
+            checkImageView
         ].forEach { addSubview($0) }
 
         [
@@ -138,6 +154,11 @@ extension RoutineCollectionViewCell {
             imageView.height.equalToSuperview().multipliedBy(0.3)
             imageView.centerX.equalToSuperview()
         }
+        
+        checkImageView.snp.makeConstraints { imageView in
+            imageView.center.equalToSuperview()
+            imageView.size.equalToSuperview().multipliedBy(0.5)
+        }
 
         clipsToBounds = true
         layer.cornerRadius = Self.cornerRadius
@@ -154,7 +175,7 @@ extension RoutineCollectionViewCell {
 
     // 셀 데이터 초기화
     private func resetData() {
-        routine = nil
+        wholeData = nil
         backgroundColor = .clear
         stickerImageView.image = nil
         titleLabel.text = nil
@@ -170,12 +191,15 @@ extension RoutineCollectionViewCell {
 
     // 뷰에 루틴 데이터 적용
     private func updateData() {
-        guard let routine = routine else { return }
-
+        guard let wholeData else { return }
+        let routine = wholeData.routine
+        let result = wholeData.result
+        
         updateBackgroundColor(routine.color)
         updateTitleLabel(routine.title)
         updateStickerImageView(routine.sticker)
         updateStopMarkView(routine.stopDate == nil)
+        updateResult(result.isCompleted)
     }
 
     // 보드 컬러 업데이트
@@ -198,6 +222,10 @@ extension RoutineCollectionViewCell {
     // 루틴 중단마크 업데이트
     private func updateStopMarkView(_ stop: Bool) {
         stopMarkImageView.isHidden = stop
+    }
+    
+    private func updateResult(_ isCompleted: Bool) {
+        checkImageView.isHidden = !isCompleted
     }
 
 }

--- a/Routine/Routine/Views/Cells/RoutineCollectionViewCell.swift
+++ b/Routine/Routine/Views/Cells/RoutineCollectionViewCell.swift
@@ -61,6 +61,7 @@ class RoutineCollectionViewCell: UICollectionViewCell {
         let imageView = UIImageView()
         
         imageView.backgroundColor = .clear
+        
         imageView.image = UIImage(systemName: "minus.circle")
         imageView.contentMode = .scaleAspectFit
         imageView.isHidden = true
@@ -72,11 +73,23 @@ class RoutineCollectionViewCell: UICollectionViewCell {
     private let checkImageView: UIImageView = {
         let imageView = UIImageView()
         
+        imageView.contentMode = .scaleAspectFit
         imageView.backgroundColor = .clear
-        imageView.image = UIImage(systemName: "checkmark.square")
-        imageView.tintColor = .red
+//        imageView.image =
+        imageView.tintColor = .white
         imageView.isHidden = true
        
+        let checkImage = UIImage(systemName: "checkmark.rectangle.portrait.fill")?.withTintColor(.green.withAlphaComponent(0.8))
+        
+        let imageSize = CGSize(width: 50, height: 50)
+        let renderer = UIGraphicsImageRenderer(size: imageSize)
+        let resizedCheckImage = renderer.image { _ in
+            checkImage?.draw(in: .init(origin: .zero, size: imageSize))
+        }
+        
+        imageView.image = resizedCheckImage
+        imageView.tintColor = .white
+
         return imageView
     }()
 
@@ -100,7 +113,8 @@ class RoutineCollectionViewCell: UICollectionViewCell {
 // MARK: - 외부 사용 메서드
 
 extension RoutineCollectionViewCell {
-    
+        
+    /// 데이터 적용
     func configureData(_ wholeData: WholeData) {
         self.wholeData = wholeData
     }

--- a/Routine/Routine/Views/Cells/RoutineCollectionViewCell.swift
+++ b/Routine/Routine/Views/Cells/RoutineCollectionViewCell.swift
@@ -76,18 +76,16 @@ class RoutineCollectionViewCell: UICollectionViewCell {
         
         imageView.contentMode = .scaleAspectFit
         imageView.backgroundColor = .clear
-//        imageView.image =
-        imageView.tintColor = .white
         imageView.isHidden = true
-       
-        let checkImage = UIImage(systemName: "checkmark.rectangle.portrait.fill")?.withTintColor(.green.withAlphaComponent(0.8))
         
-        let imageSize = CGSize(width: 50, height: 50)
+        let checkImage = UIImage(systemName: "checkmark.square.fill")?.withTintColor(.green.withAlphaComponent(0.8))
+        
+        let imageSize = CGSize(width: 30, height: 25)
         let renderer = UIGraphicsImageRenderer(size: imageSize)
         let resizedCheckImage = renderer.image { _ in
             checkImage?.draw(in: .init(origin: .zero, size: imageSize))
         }
-        
+                
         imageView.image = resizedCheckImage
         imageView.tintColor = .white
 


### PR DESCRIPTION
## 개요 :mag:
`RoutineResult` 를 뷰와 연결했습니다.

![Simulator Screen Recording - iPhone 16 Pro - 2024-12-22 at 20 12 57](https://github.com/user-attachments/assets/bdcf98cb-0445-4f2e-b947-28c612949f0d)


## 작업사항 :memo:

- `WholeData` : (`RoutineData`, `RoutineResult`) 형태의 데이터
- `WholeDataManager` : `RoutineManager`, `RoutineResultManager`를 통해 `WholeData`를 관리하는 싱글톤 객체 
- `MainRoutineViewController` : 루틴 셀 선택을 통한 값 변경사항을 저장