### PR TITLE
[feature/RP-103-CreateVC] Implement CreateVC

### DIFF
--- a/Routine/Routine/Models/MockData.swift
+++ b/Routine/Routine/Models/MockData.swift
@@ -8,7 +8,7 @@ struct MockData {
     
     static let oldRoutine = RoutineData(id: Self.uuid,
                                         title: "1970년 루틴",
-                                        color: .blue,
+                                        color: .pastelPink,
                                         sticker: "goforward.15.ar",
                                         startDate: Self.date,
                                         stopDate: nil,
@@ -17,7 +17,7 @@ struct MockData {
     
     static let newRoutine = RoutineData(id: Self.uuid,
                                         title: "newRoutine",
-                                        color: .yello,
+                                        color: .pastelYellow,
                                         sticker: "applelogo",
                                         startDate: Self.date,
                                         stopDate: nil,
@@ -25,7 +25,7 @@ struct MockData {
                                         alarm: nil)
     
     static let currentRoutine = RoutineData(title: "currentRoutine",
-                                            color: .green,
+                                            color: .pastelPeach,
                                             sticker: "applelogo",
                                             stopDate: nil,
                                             repeatation: .default,

--- a/Routine/Routine/Models/RoutineData/BoardColor.swift
+++ b/Routine/Routine/Models/RoutineData/BoardColor.swift
@@ -10,45 +10,94 @@ import UIKit
 ///보드 컬러 열거형
 ///
 ///uiColor() 메서드를 통해 UIColor를 반환
-///
-enum BoardColor: Codable, CaseIterable, Comparable {
-    
+
+enum BoardColor: Int, Codable, CaseIterable {
+
     case white
-    case yello
-    case blue
-    case green
-    case red
+    case pastelYellow
+    case pastelPink
+    case pastelPeach
+    case ivory
+    case creamyBeige
+    case softIvory
+    case mintGreen
+    case pastelGreen
+    case lightAqua
+    case softAqua
+    case lilac
 
     func uiColor() -> UIColor {
         switch self {
         case .white:
-            return UIColor(red: cgFloat(200),
-                           green: cgFloat(150),
-                           blue: cgFloat(200),
-                           alpha: 1)
-            
-        case .yello:
-            return UIColor(red: cgFloat(150),
-                           green: cgFloat(200),
+            return UIColor(red: cgFloat(255),
+                           green: cgFloat(255),
                            blue: cgFloat(255),
                            alpha: 1)
-            
-        case .blue:
-            return UIColor(red: cgFloat(130),
-                           green: cgFloat(170),
-                           blue: cgFloat(200),
+
+        case .pastelYellow:
+            return UIColor(red: cgFloat(244),
+                           green: cgFloat(244),
+                           blue: cgFloat(245),
                            alpha: 1)
-            
-        case .green:
-            return UIColor(red: cgFloat(170),
-                           green: cgFloat(200),
+
+        case .pastelPink:
+            return UIColor(red: cgFloat(254),
+                           green: cgFloat(243),
+                           blue: cgFloat(245),
+                           alpha: 1)
+
+        case .pastelPeach:
+            return UIColor(red: cgFloat(253),
+                           green: cgFloat(247),
+                           blue: cgFloat(243),
+                           alpha: 1)
+
+        case .ivory:
+            return UIColor(red: cgFloat(251),
+                           green: cgFloat(251),
+                           blue: cgFloat(241),
+                           alpha: 1)
+
+        case .creamyBeige:
+            return UIColor(red: cgFloat(251),
+                           green: cgFloat(247),
+                           blue: cgFloat(236),
+                           alpha: 1)
+
+        case .softIvory:
+            return UIColor(red: cgFloat(251),
+                           green: cgFloat(252),
+                           blue: cgFloat(241),
+                           alpha: 1)
+
+        case .mintGreen:
+            return UIColor(red: cgFloat(244),
+                           green: cgFloat(250),
+                           blue: cgFloat(236),
+                           alpha: 1)
+
+        case .pastelGreen:
+            return UIColor(red: cgFloat(241),
+                           green: cgFloat(251),
+                           blue: cgFloat(247),
+                           alpha: 1)
+
+        case .lightAqua:
+            return UIColor(red: cgFloat(241),
+                           green: cgFloat(252),
+                           blue: cgFloat(251),
+                           alpha: 1)
+
+        case .softAqua:
+            return UIColor(red: cgFloat(240),
+                           green: cgFloat(252),
+                           blue: cgFloat(251),
+                           alpha: 1)
+
+        case .lilac:
+            return UIColor(red: cgFloat(244),
+                           green: cgFloat(243),
                            blue: cgFloat(255),
-                           alpha: 1)
-            
-        case .red:
-            return UIColor(red: cgFloat(160),
-                           green: cgFloat(170),
-                           blue: cgFloat(230),
                            alpha: 1)
         }
     }

--- a/Routine/Routine/Models/RoutineSuggestionData.swift
+++ b/Routine/Routine/Models/RoutineSuggestionData.swift
@@ -20,18 +20,23 @@ struct SuggestionData {
             routineSuggestionData: [
                 RoutineData(
                     title: "침구류 정리",
-                    color: .white,
-                    sticker: "heart",
+                    color: .ivory,
+                    sticker: "bed.double.fill",
                     repeatation: .default),
                 RoutineData(
-                    title: "물한컵 마시기",
-                    color: .blue,
-                    sticker: "heart",
+                    title: "물 한컵 마시기",
+                    color: .mintGreen,
+                    sticker: "cup.and.saucer.fill",
                     repeatation: .default),
                 RoutineData(
                     title: "모닝 커피 한잔",
-                    color: .yello,
-                    sticker: "heart",
+                    color: .pastelPeach,
+                    sticker: "takeoutbag.and.cup.and.straw.fill",
+                    repeatation: .default),
+                RoutineData(
+                    title: "아침 운동하기",
+                    color: .pastelGreen,
+                    sticker: "figure.walk",
                     repeatation: .default)
             ]),
         SuggestionData(
@@ -40,18 +45,23 @@ struct SuggestionData {
             routineSuggestionData: [
                 RoutineData(
                     title: "먼지 제거",
-                    color: .white,
-                    sticker: "heart",
+                    color: .lightAqua,
+                    sticker: "star.fill",
                     repeatation: .default),
                 RoutineData(
                     title: "세탁 하기",
-                    color: .blue,
-                    sticker: "heart",
+                    color: .pastelGreen,
+                    sticker: "washer.fill",
                     repeatation: .default),
                 RoutineData(
                     title: "화분 물주기",
-                    color: .green,
-                    sticker: "heart",
+                    color: .softIvory,
+                    sticker: "pawprint.fill",
+                    repeatation: .default),
+                RoutineData(
+                    title: "쓰레기 버리기",
+                    color: .pastelYellow,
+                    sticker: "trash.fill",
                     repeatation: .default)
             ]),
         SuggestionData(
@@ -60,21 +70,27 @@ struct SuggestionData {
             routineSuggestionData: [
                 RoutineData(
                     title: "하루 10분 독서",
-                    color: .green,
-                    sticker: "heart",
+                    color: .lilac,
+                    sticker: "book.fill",
                     repeatation: .default),
                 RoutineData(
                     title: "다이어리 쓰기",
-                    color: .yello,
-                    sticker: "heart",
+                    color: .pastelYellow,
+                    sticker: "calendar",
                     repeatation: .default),
                 RoutineData(
                     title: "등교 하기",
                     color: .white,
-                    sticker: "heart",
+                    sticker: "person.fill",
+                    repeatation: .default),
+                RoutineData(
+                    title: "새로운 기술 배우기",
+                    color: .softAqua,
+                    sticker: "lightbulb.fill",
                     repeatation: .default)
             ])
     ]
+
 
     var sectionTitle: String
     var subTitle: String

--- a/Routine/Routine/ViewControllers/CreateRoutineViewController.swift
+++ b/Routine/Routine/ViewControllers/CreateRoutineViewController.swift
@@ -13,6 +13,8 @@ class CreateRoutineViewController: UIViewController {
     let routineEditorView = RoutineEditorView()
 
     private var selectedColorIndex = 0 // 선택된 색상 인덱스 저장
+    private var sticker = "house.fill"
+    private var color: BoardColor = BoardColor.white
 
     override func loadView() {
         super.loadView()
@@ -42,6 +44,21 @@ class CreateRoutineViewController: UIViewController {
         routineEditorView.stickerButton.addAction(UIAction{ [weak self] _ in
             self?.stickerButtonTapped()
         }, for: .touchUpInside)
+
+        // 추가하기 버튼 액션 연결
+        routineEditorView.addButton.addAction(UIAction{ [weak self] _ in
+            self?.addButtonTapped()
+        }, for: .touchUpInside)
+
+        // 뒤로가기, 삭제하기 버튼 액션 연결
+        [
+            routineEditorView.backButton,
+            routineEditorView.deleteButton
+        ].forEach {
+            $0.addAction(UIAction{ [weak self] _ in
+                self?.backButtonTapped()
+            }, for: .touchUpInside)
+        }
     }
 }
 
@@ -74,28 +91,43 @@ extension CreateRoutineViewController {
         modalVC.delegate = self
         present(modalVC, animated: true)
     }
+
+    // 추가하기 버튼 눌리면 실행
+    private func addButtonTapped() {
+        let data = RoutineData(
+            title: routineEditorView.titleTextField.text ?? "",
+            color: color,
+            sticker: sticker,
+            repeatation: Repeatation.default
+        )
+        RoutineManager.shared.create(data)
+        navigationController?.popToRootViewController(animated: true)
+    }
+
+    // 뒤로가기, 삭제하기 버튼 눌리면 실행
+    private func backButtonTapped() {
+        navigationController?.popToRootViewController(animated: true)
+    }
 }
 
 // MARK: - SelectColorViewController Delegate 설정
 
 extension CreateRoutineViewController: SelectColorViewControllerDelegate {
-    func updateColor(_ viewController: SelectColorViewController, color: [Double], selectedIndex: Int) {
-        let rColor = color[0] / 256.0
-        let gColor = color[1] / 256.0
-        let bColor = color[2] / 256.0
-        let colors = UIColor(red: rColor, green: gColor, blue: bColor, alpha: 1)
-        routineEditorView.colorButton.backgroundColor = colors
-        routineEditorView.titleInputView.backgroundColor = colors
+    func updateColor(_ viewController: SelectColorViewController, color: BoardColor, selectedIndex: Int) {
+        let uiColor = BoardColor(rawValue: selectedIndex)?.uiColor()
+        routineEditorView.colorButton.backgroundColor = uiColor
+        routineEditorView.titleInputView.backgroundColor = uiColor
         self.selectedColorIndex = selectedIndex
+        self.color = color
     }
-
 }
 
 // MARK: - SelectStickerViewController Delegate 설정
 
 extension CreateRoutineViewController: SelectStickerViewControllerDelegate {
     func updateSticker(_ viewController: UIViewController, sticker: String) {
-        routineEditorView.titleInputImage.image = UIImage(systemName: sticker)
+        routineEditorView.titleInputImage.image = UIImage(systemName: sticker)?.withRenderingMode(.alwaysOriginal)
+        self.sticker = sticker
     }
 
 }

--- a/Routine/Routine/ViewControllers/SelectColorViewController.swift
+++ b/Routine/Routine/ViewControllers/SelectColorViewController.swift
@@ -9,25 +9,25 @@ import UIKit
 
 import SnapKit
 
-// 색상 데이터
-let colorData = [
-    [255.0, 255.0, 255.0],
-    [244.0, 244.0, 245.0],
-    [254.0, 243.0, 245.0],
-    [253.0, 247.0, 243.0],
-    [251.0, 251.0, 241.0],
-    [251.0, 247.0, 236.0],
-    [251.0, 252.0, 241.0],
-    [244.0, 250.0, 236.0],
-    [241.0, 251.0, 247.0],
-    [241.0, 252.0, 251.0],
-    [240.0, 252.0, 251.0],
-    [244.0, 243.0, 255.0]
-]
+//// 색상 데이터
+//let colorData = [
+//    [255.0, 255.0, 255.0],
+//    [244.0, 244.0, 245.0],
+//    [254.0, 243.0, 245.0],
+//    [253.0, 247.0, 243.0],
+//    [251.0, 251.0, 241.0],
+//    [251.0, 247.0, 236.0],
+//    [251.0, 252.0, 241.0],
+//    [244.0, 250.0, 236.0],
+//    [241.0, 251.0, 247.0],
+//    [241.0, 252.0, 251.0],
+//    [240.0, 252.0, 251.0],
+//    [244.0, 243.0, 255.0]
+//]
 
 // SelectColorViewControllerDelegate 프로토콜
 protocol SelectColorViewControllerDelegate: AnyObject {
-    func updateColor(_ viewController: SelectColorViewController, color: [Double], selectedIndex: Int)
+    func updateColor(_ viewController: SelectColorViewController, color: BoardColor, selectedIndex: Int)
 }
 
 class SelectColorViewController: UIViewController {
@@ -101,7 +101,8 @@ extension SelectColorViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedIneex = indexPath.item
-        self.delegate?.updateColor(self, color: colorData[indexPath.item], selectedIndex: selectedIneex)
+        guard let color = BoardColor(rawValue: indexPath.item) else { return }
+        self.delegate?.updateColor(self, color: color, selectedIndex: selectedIneex)
         self.dismiss(animated: true)
     }
 }
@@ -110,13 +111,16 @@ extension SelectColorViewController: UICollectionViewDelegate {
 
 extension SelectColorViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        12
+        BoardColor.allCases.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "cell", for: indexPath) as? ColorCollectionViewCell else {
             return UICollectionViewCell() }
-        cell.setupColor(colorData[indexPath.item])
+
+        if let color = BoardColor(rawValue: indexPath.item) {
+            cell.setupColor(color)
+        }
 
         if indexPath.item == selectedIneex {
             cell.setupCheck(true)

--- a/Routine/Routine/ViewControllers/SelectColorViewController.swift
+++ b/Routine/Routine/ViewControllers/SelectColorViewController.swift
@@ -9,22 +9,6 @@ import UIKit
 
 import SnapKit
 
-//// 색상 데이터
-//let colorData = [
-//    [255.0, 255.0, 255.0],
-//    [244.0, 244.0, 245.0],
-//    [254.0, 243.0, 245.0],
-//    [253.0, 247.0, 243.0],
-//    [251.0, 251.0, 241.0],
-//    [251.0, 247.0, 236.0],
-//    [251.0, 252.0, 241.0],
-//    [244.0, 250.0, 236.0],
-//    [241.0, 251.0, 247.0],
-//    [241.0, 252.0, 251.0],
-//    [240.0, 252.0, 251.0],
-//    [244.0, 243.0, 255.0]
-//]
-
 // SelectColorViewControllerDelegate 프로토콜
 protocol SelectColorViewControllerDelegate: AnyObject {
     func updateColor(_ viewController: SelectColorViewController, color: BoardColor, selectedIndex: Int)

--- a/Routine/Routine/Views/Cells/ColorCollectionViewCell.swift
+++ b/Routine/Routine/Views/Cells/ColorCollectionViewCell.swift
@@ -51,12 +51,10 @@ class ColorCollectionViewCell: UICollectionViewCell {
 
 extension ColorCollectionViewCell {
     // 색상 설정
-    func setupColor(_ color: [Double]) {
-        let rColor = color[0] / 256.0
-        let gColor = color[1] / 256.0
-        let bColor = color[2] / 256.0
-        let colors = UIColor(red: rColor, green: gColor, blue: bColor, alpha: 1)
-        colorImageView.backgroundColor = colors
+    func setupColor(_ color: BoardColor) {
+
+        let uiColor = color.uiColor()
+        colorImageView.backgroundColor = uiColor
     }
 
     // 선택된 색상 체크 표시

--- a/Routine/Routine/Views/Cells/RoutineSuggestionCollectionViewCell.swift
+++ b/Routine/Routine/Views/Cells/RoutineSuggestionCollectionViewCell.swift
@@ -38,7 +38,14 @@ class RoutineSuggestionCollectionViewCell: UICollectionViewCell {
         itemLabel.font = .systemFont(ofSize: 15)
         itemLabel.textColor = .black
 
-        imageView.image = UIImage(named: "test")
+        if let sticker = item?.sticker {
+            imageView.image = UIImage(systemName: sticker)?.withRenderingMode(.alwaysOriginal)
+        }
+
+        if let color = item?.color.uiColor() {
+            view.backgroundColor = color
+        }
+
         imageView.contentMode = .scaleAspectFit
 
 

--- a/Routine/Routine/Views/Cells/StickerCollectionViewCell.swift
+++ b/Routine/Routine/Views/Cells/StickerCollectionViewCell.swift
@@ -43,6 +43,6 @@ class StickerCollectionViewCell: UICollectionViewCell {
     // MARK: - 데이터 설정
 
     func configure(_ stickerName: String) {
-        stickerImageView.image = UIImage(systemName: stickerName)
+        stickerImageView.image = UIImage(systemName: stickerName)?.withRenderingMode(.alwaysOriginal)
     }
 }

--- a/Routine/Routine/Views/CustomViews/RoutineEditorView.swift
+++ b/Routine/Routine/Views/CustomViews/RoutineEditorView.swift
@@ -99,7 +99,7 @@ class RoutineEditorView: UIView {
     // 타이틀 입력 이미지
     var titleInputImage: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "house.fill")
+        imageView.image = UIImage(systemName: "house.fill")?.withRenderingMode(.alwaysOriginal)
         imageView.contentMode = .scaleAspectFill
         imageView.tintColor = .black
         return imageView


### PR DESCRIPTION
## 개요 :mag:

`CreateVC`를 구현했습니다. 

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-04 at 14 38 18](https://github.com/user-attachments/assets/5771c3e6-eb6e-4b1c-b8a7-3fc8187cd8ec)

## 작업사항 :memo:

- `CreateVC` 추가하기 버튼 누르면 CoreData 저장
데이터 저장 후 RootVC로 이동합니다.

- `BoardColor` 데이터 수정 및 추가
색상 값을 변경하고 추가했습니다.